### PR TITLE
Lease: make selector a required field, change type to string

### DIFF
--- a/proto/jumpstarter/client/v1/client.proto
+++ b/proto/jumpstarter/client/v1/client.proto
@@ -79,8 +79,8 @@ message Lease {
 
   string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
-  jumpstarter.v1.LabelSelector selector = 2 [
-    (google.api.field_behavior) = OPTIONAL,
+  string selector = 2 [
+    (google.api.field_behavior) = REQUIRED,
     (google.api.field_behavior) = IMMUTABLE
   ];
   google.protobuf.Duration duration = 3 [(google.api.field_behavior) = REQUIRED];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the configuration of a key input parameter in the leasing process. Users must now provide this parameter as a plain text identifier, ensuring improved consistency and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->