### PR TITLE
Add ExporterStatus enum and status field

### DIFF
--- a/proto/jumpstarter/client/v1/client.proto
+++ b/proto/jumpstarter/client/v1/client.proto
@@ -67,17 +67,17 @@ message Exporter {
 
   string name = 1 [(google.api.field_behavior) = IDENTIFIER];
   map<string, string> labels = 2;
-  bool online = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  bool online = 3 [(google.api.field_behavior) = OUTPUT_ONLY, deprecated = true];
   ExporterStatus status = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 enum ExporterStatus {
-  EXPORTER_STATUS_UNSPECIFIED = 0;
-  EXPORTER_STATUS_OFFLINE = 1;
-  EXPORTER_STATUS_AVAILABLE = 2;
-  EXPORTER_STATUS_BEFORE_LEASE_HOOK = 3;
-  EXPORTER_STATUS_LEASE_READY = 4;
-  EXPORTER_STATUS_AFTER_LEASE_HOOK = 5;
+  EXPORTER_STATUS_UNSPECIFIED = 0;       // Unspecified exporter status
+  EXPORTER_STATUS_OFFLINE = 1;           // Exporter is offline
+  EXPORTER_STATUS_AVAILABLE = 2;         // Exporter is available to be leased
+  EXPORTER_STATUS_BEFORE_LEASE_HOOK = 3; // Exporter is executing before lease hook(s)
+  EXPORTER_STATUS_LEASE_READY = 4;       // Exporter is leased and ready to accept commands
+  EXPORTER_STATUS_AFTER_LEASE_HOOK = 5;  // Exporter is executing after lease hook(s)
 }
 
 message Lease {


### PR DESCRIPTION
Add exporter status enum as proposed in jumpstarter-dev/jumpstarter#104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API: Exporter objects now include a read-only status field reflecting availability and lifecycle stage (Unspecified, Offline, Available, Before Lease Hook, Lease Ready, After Lease Hook).
  * The status field is output-only and appears in API responses wherever Exporter is returned.

* **Chores**
  * Deprecated the existing read-only online flag for Exporter; clients remain backward compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->