### PR TITLE
add "descriptions" field to GetReport

### DIFF
--- a/proto/jumpstarter/v1/jumpstarter.proto
+++ b/proto/jumpstarter/v1/jumpstarter.proto
@@ -67,6 +67,8 @@ message DriverInstanceReport {
   string uuid = 1; // a unique id within the exporter
   optional string parent_uuid = 2; // optional, if device has a parent device
   map<string, string> labels = 3;
+  optional string description = 4; // optional custom driver description for CLI
+  map<string, string> methods_description = 5; // method name -> help text for CLI
 }
 
 message RegisterResponse {


### PR DESCRIPTION
for storing custom Driver descriptions to display in jmp shell CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Report responses now include per-driver descriptive text for richer display and filtering.
  - Responses also include per-method help text (keyed by method name) to power CLI-friendly help and UI tooltips.
- Compatibility
  - Backward-compatible addition; existing integrations continue to work while gaining access to the new descriptions and method help data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->