### PR TITLE
add "only_active" field to ListLeaseRequest

### DIFF
--- a/proto/jumpstarter/client/v1/client.proto
+++ b/proto/jumpstarter/client/v1/client.proto
@@ -140,6 +140,7 @@ message ListLeasesRequest {
   int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
   string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
   string filter = 4 [(google.api.field_behavior) = OPTIONAL];
+  optional bool only_active = 5 [(google.api.field_behavior) = OPTIONAL];
 }
 
 message ListLeasesResponse {


### PR DESCRIPTION
defaults to true, pass "false" to get the ended leases as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional filter to lease listings to show only active leases. This enables quicker discovery and cleaner results when browsing leases.
  * The feature is fully backward-compatible: existing requests behave the same unless the new filter is used.
  * API consumers can opt in by specifying the new parameter; no changes are required for current integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->