### PR TITLE
Add support for requesting a lease by device name directly

### DIFF
--- a/proto/jumpstarter/client/v1/client.proto
+++ b/proto/jumpstarter/client/v1/client.proto
@@ -83,10 +83,15 @@ message Lease {
 
   string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
-  string selector = 2 [
-    (google.api.field_behavior) = REQUIRED,
-    (google.api.field_behavior) = IMMUTABLE
-  ];
+  oneof exporter_selection {
+    string selector = 2 [(google.api.field_behavior) = IMMUTABLE];
+   
+    string exporter_name = 12 [
+      (google.api.field_behavior) = IMMUTABLE,
+      (google.api.resource_reference) = {type: "jumpstarter.dev/Exporter"}
+    ];
+  }
+  
   optional google.protobuf.Duration duration = 3;
   google.protobuf.Duration effective_duration = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
   optional google.protobuf.Timestamp begin_time = 5;


### PR DESCRIPTION
Replace the single selector field with a oneof exporter_selection, allowing leases to target either exporters via label selector or a specific device by resource name. 
Both options are immutable to preserve lease semantics.

The field is no longer marked as REQUIRED, as the controller now validates whether a value was provided.

Issue: https://github.com/jumpstarter-dev/jumpstarter/issues/638
Related to: https://github.com/jumpstarter-dev/jumpstarter-controller/pull/208